### PR TITLE
Add refresh button for device list and load preferences on initialization

### DIFF
--- a/data/config.css
+++ b/data/config.css
@@ -190,6 +190,43 @@ h3 {
     min-width: 300px;
 }
 
+.devices-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.5em;
+}
+
+.devices-header h3 {
+    margin: 0;
+}
+
+.refresh-button {
+    background: #2196f3;
+    color: white;
+    border: 1px solid #1976d2;
+    border-radius: 6px;
+    padding: 0.6em;
+    cursor: pointer;
+    font-size: 1.2em;
+    transition: all 0.3s ease;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.refresh-button:hover {
+    background: #1976d2;
+}
+
+.refresh-button:active {
+    background: #1565c0;
+    transform: scale(0.95);
+}
+
 .device-grid {
     display: flex;
     flex-direction: column;

--- a/data/config.html
+++ b/data/config.html
@@ -63,7 +63,16 @@
             </div>
         </div>
         <div class="devices-container">
-            <h3>ESP-Geräte</h3>
+            <div class="devices-header">
+                <h3>ESP-Geräte</h3>
+                <button
+                    id="refreshDevicesBtn"
+                    class="refresh-button"
+                    title="Geräte aktualisieren"
+                >
+                    🔄
+                </button>
+            </div>
             <div class="device-grid" id="devicesContainer">
                 <!-- Geräte werden hier dynamisch eingefügt -->
             </div>

--- a/data/config.js
+++ b/data/config.js
@@ -33,6 +33,11 @@ function loadDeviceInfo() {
     // Lade Distanz-Einstellungen
     loadDistanceSettings();
 
+    // Lade Gerätepräferenzen
+    loadDevicePreferences();
+}
+
+function loadDevicePreferences() {
     fetch("/preferences")
         .then((response) => response.text())
         .then((data) => {
@@ -133,7 +138,10 @@ function setupEventListeners() {
 
     // Refresh Devices Button
     document.getElementById("refreshDevicesBtn").onclick = function () {
+        // Neue Geräte suchen
         discoverDevices();
+        // Gespeicherte Geräte neu laden
+        loadDevicePreferences();
     };
 }
 

--- a/data/config.js
+++ b/data/config.js
@@ -130,6 +130,11 @@ function setupEventListeners() {
                 });
         }
     };
+
+    // Refresh Devices Button
+    document.getElementById("refreshDevicesBtn").onclick = function () {
+        discoverDevices();
+    };
 }
 
 function updateStatusDisplay(status) {


### PR DESCRIPTION
Introduce a refresh button to update the device list and load device preferences during initialization and on button click.