### PR TITLE
Remove old initialization after DOM load

### DIFF
--- a/data/config.js
+++ b/data/config.js
@@ -491,9 +491,3 @@ function saveDeviceRole(selectElement, mac, isSelf) {
 function discoverDevices() {
     fetch("/discover", { method: "POST" });
 }
-
-// Initialisierung nach DOM-Load
-document.addEventListener("DOMContentLoaded", function () {
-    loadThreshold();
-    loadBaseDistance();
-});


### PR DESCRIPTION
Eliminate the outdated event listener for DOMContentLoaded to streamline the initialization process.